### PR TITLE
Terraform state파일을 이용한 상태 관리

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@
 - 작업 내용들을 파일 레이아웃(디렉토리)를 통해 서로 격리함
 - service파트의 webserver & DB, tfstate파일 저장을 위한 global파트의 s3를 디렉토리로 구분하여 구축
 - 디렉토리 구조
+
 ![image](https://github.com/AhnDo0/Terraform-test/assets/51705063/a60879f9-a079-4958-b3d7-c055bc39098b)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## Terraform state파일을 이용한 상태 관리 ##
+- Terraform의 상태가 기록된 tfstate파일을 이용해 상태 관리
+- 주소, 이름 등 민감정보가 들어있으므로 공개된 Github등에 업로드 X => 안전한 곳에 암호화하여 저장
+
+## 작업 내용 ##
+- Terraform의 상태 파일을 AWS DynamoDB와 S3를 통해 저장
+- webserver, MySQL의 백엔드 예제 인프라 구축
+- 로드밸런서를 이용하여 webserver에 대해 ASG(Auto Scaling Group) 구축
+- 위의 작업들은 Terraform 코드를 이용해 웹 콘솔 작업 없이 코드를 통해서 프로비저닝
+
+## 파일 레이아웃을 통한 격리 ##
+- 작업 내용들을 파일 레이아웃(디렉토리)를 통해 서로 격리함
+- service파트의 webserver & DB, tfstate파일 저장을 위한 global파트의 s3를 디렉토리로 구분하여 구축
+- 디렉토리 구조
+![image](https://github.com/AhnDo0/Terraform-test/assets/51705063/a60879f9-a079-4958-b3d7-c055bc39098b)
+

--- a/global/s3/.terraform.lock.hcl
+++ b/global/s3/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.34.0"
+  hashes = [
+    "h1:Tbq6dKE+XyXmkup6+7eQj2vH+eCJipk8R3VXhebVYi4=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
+  ]
+}

--- a/global/s3/main.tf
+++ b/global/s3/main.tf
@@ -1,0 +1,55 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "terraform-state-cloudwave-15"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "enabled" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  bucket = aws_s3_bucket.terraform_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access" {
+  bucket = aws_s3_bucket.terraform_state.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name = "terraform-locks"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key = "LockID"
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket = "terraform-state-cloudwave-15"
+    key = "global/s3/terraform.tfstate"
+    region = "ap-northeast-2"
+    dynamodb_table = "terraform-locks"
+    encrypt = true
+  }
+}

--- a/global/s3/outputs.tf
+++ b/global/s3/outputs.tf
@@ -1,0 +1,9 @@
+output "s3_bucket_arn" {
+  value = aws_s3_bucket.terraform_state.arn
+  description = "The ARN of the S3 bucket"
+}
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.terraform_locks.name
+  description = "The name of the DynamoDB table"
+}

--- a/stage/data-stores/mysql/.terraform.lock.hcl
+++ b/stage/data-stores/mysql/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.34.0"
+  hashes = [
+    "h1:Tbq6dKE+XyXmkup6+7eQj2vH+eCJipk8R3VXhebVYi4=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
+  ]
+}

--- a/stage/data-stores/mysql/main.tf
+++ b/stage/data-stores/mysql/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "terraform-state-cloudwave-15"
+    key = "stage/data-stores/mysql/terraform.tfstate"
+    region = "ap-northeast-2"
+    dynamodb_table = "terraform-locks"
+    encrypt = true
+  }
+}
+
+resource "aws_db_instance" "example" {
+  identifier_prefix = "terraform-mysql"
+  engine = "mysql"
+  allocated_storage = 10
+  instance_class = "db.t2.micro"
+  skip_final_snapshot = true
+  db_name = "example_database"
+
+  username = var.db_username
+  password = var.db_password
+}

--- a/stage/data-stores/mysql/outputs.tf
+++ b/stage/data-stores/mysql/outputs.tf
@@ -1,0 +1,8 @@
+output "address" {
+  value = aws_db_instance.example.address
+  description = "Connect to the database at the endpoint"
+}
+output "port" {
+  value = aws_db_instance.example.port
+  description = "The port the database is listening on"
+}

--- a/stage/data-stores/mysql/variables.tf
+++ b/stage/data-stores/mysql/variables.tf
@@ -1,0 +1,11 @@
+variable "db_username" {
+  description = "The username for the database"
+  type = string
+  sensitive = true
+}
+
+variable "db_password" {
+  description = "The password for the database"
+  type = string
+  sensitive = true
+}

--- a/stage/services/webserver-cluster/.terraform.lock.hcl
+++ b/stage/services/webserver-cluster/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.34.0"
+  hashes = [
+    "h1:Tbq6dKE+XyXmkup6+7eQj2vH+eCJipk8R3VXhebVYi4=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
+  ]
+}

--- a/stage/services/webserver-cluster/main.tf
+++ b/stage/services/webserver-cluster/main.tf
@@ -1,0 +1,111 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+resource "aws_security_group" "alb" {
+  name = "terraform-example-alb"
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "example" {
+  name = "terraform-asg-example"
+  load_balancer_type = "application"
+  subnets = data.aws_subnets.default.ids
+  security_groups = [aws_security_group.alb.id]
+}
+
+resource "aws_lb_target_group" "asg" {
+  name = "terraform-asg-example"
+  port = var.server_port
+  protocol = "HTTP"
+  vpc_id = data.aws_vpc.default.id
+  health_check {
+  path = "/"
+  protocol = "HTTP"
+  matcher = "200"
+  interval = 15
+  timeout = 3
+  healthy_threshold = 2
+  unhealthy_threshold = 2
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.example.arn
+  port = 80
+  protocol = "HTTP"
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "404: page not found"
+      status_code = 404
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "asg" {
+  listener_arn = aws_lb_listener.http.arn
+  priority = 100
+  condition {
+    path_pattern {
+      values = ["*"]
+    }
+  }
+  action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.asg.arn
+  }
+}
+
+resource "aws_launch_configuration" "example" {
+  image_id = "ami-09eb4311cbaecf89d"
+  instance_type = "t3.micro"
+  security_groups = [aws_security_group.instance.id]
+
+  user_data = templatefile("user-data.sh", {
+  server_port = var.server_port
+  db_address = data.terraform_remote_state.db.outputs.address
+  db_port = data.terraform_remote_state.db.outputs.port
+  })
+
+  lifecycle{
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "example" {
+  launch_configuration = aws_launch_configuration.example.name
+  vpc_zone_identifier = data.aws_subnets.default.ids
+  target_group_arns = [aws_lb_target_group.asg.arn]
+  health_check_type = "ELB"
+  min_size = 2
+  max_size = 10
+  tag {
+    key = "Name"
+    value = "terraform-asg-example"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name = "terraform-example-instance"
+
+  ingress {
+    from_port = var.server_port
+    to_port = var.server_port
+    protocol = "tcp"
+    cidr_blocks = [ "0.0.0.0/0" ]
+  }
+}

--- a/stage/services/webserver-cluster/outputs.tf
+++ b/stage/services/webserver-cluster/outputs.tf
@@ -1,0 +1,4 @@
+output "alb_dns_name" {
+  value = aws_lb.example.dns_name
+  description = "The domain name of the load balancer"
+}

--- a/stage/services/webserver-cluster/user-data.sh
+++ b/stage/services/webserver-cluster/user-data.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cat > index.html <<EOF
+<h1>Hello, World</h1>
+<p>DB address: ${db_address}</p>
+<p>DB port: ${db_port}</p>
+EOF
+nohup busybox httpd -f -p ${server_port} &

--- a/stage/services/webserver-cluster/variables.tf
+++ b/stage/services/webserver-cluster/variables.tf
@@ -1,0 +1,25 @@
+variable "server_port" {
+  description = "server port for http request"
+  type = number
+  default = 8080
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "terraform_remote_state" "db" {
+  backend = "s3" 
+  config = {
+  bucket = "terraform-state-cloudwave-15"
+  key = "stage/data-stores/mysql/terraform.tfstate"
+  region = "ap-northeast-2"
+  }
+}


### PR DESCRIPTION
## Terraform state파일을 이용한 상태 관리 ##
- Terraform의 상태가 기록된 tfstate파일을 이용해 상태 관리
- 주소, 이름 등 민감정보가 들어있으므로 공개된 Github등에 업로드 X => 안전한 곳에 암호화하여 저장

## 작업 내용 ##
- Terraform의 상태 파일을 AWS DynamoDB와 S3를 통해 저장
- webserver, MySQL의 백엔드 예제 인프라 구축
- 로드밸런서를 이용하여 webserver에 대해 ASG(Auto Scaling Group) 구축
- 위의 작업들은 Terraform 코드를 이용해 웹 콘솔 작업 없이 코드를 통해서 프로비저닝