### PR TITLE
Module로 재사용 가능한 인프라 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+## 모듈로 재사용 가능한 인프라 구성 ##
+- 모듈은 재사용, 유지 관리 가능한 Terraform 코드를 작성하는 핵심 요소
+- 여러 위치에서 재사용 가능한 모듈을 만들고, 이를 참조하는 방식을 통해 똑같은 코드를 여러 곳에 작성할 필요 없음
+
+## 작업 내용 ##
+- #1 에서 했던 webserver 환경 구축을 모듈로 분리
+- 다른 환경(stage, prod디렉토리)에서는 webserver환경 구축을 모듈을 참조하도록 하는 terraform코드만 작성하면 됨
+- 모듈을 이용하여 webserver인프라 프로비저닝
+- 모듈 지역화(local)을 이용하여 변수를 locals.tf파일에 정의해두고, 이 변수를 모듈 전체에서 사용 가능하게함
+
+## 디렉토리 구조 ##
+- #1 작업내용에 이어 새로 생성한 module, prod와 stage/services의 webserver-cluster에서 작업함
+  ![image](https://github.com/AhnDo0/Terraform-test/assets/51705063/56203608-95e2-458e-a01d-c94ab476e5d0)

--- a/module/services/webserver-cluster/.terraform.lock.hcl
+++ b/module/services/webserver-cluster/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.34.0"
+  hashes = [
+    "h1:Tbq6dKE+XyXmkup6+7eQj2vH+eCJipk8R3VXhebVYi4=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
+  ]
+}

--- a/module/services/webserver-cluster/local.tf
+++ b/module/services/webserver-cluster/local.tf
@@ -1,0 +1,7 @@
+locals {
+  http_port = 80
+  any_port = 0
+  any_protocol = "-1"
+  tcp_protocol = "tcp"
+  all_ips = ["0.0.0.0/0"]
+}

--- a/module/services/webserver-cluster/main.tf
+++ b/module/services/webserver-cluster/main.tf
@@ -1,0 +1,111 @@
+resource "aws_security_group" "alb" {
+  name = "${var.cluster_name}-alb"
+}
+resource "aws_security_group_rule" "allow_http_inbound" {
+  type = "ingress"
+  security_group_id = aws_security_group.alb.id
+  from_port = local.http_port
+  to_port = local.http_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+resource "aws_security_group_rule" "allow_all_outbound" {
+  type = "egress"
+  security_group_id = aws_security_group.alb.id
+  from_port = local.any_port
+  to_port = local.any_port
+  protocol = local.any_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource "aws_lb" "example" {
+  name = "${var.cluster_name}-asg-example"
+  load_balancer_type = "application"
+  subnets = data.aws_subnets.default.ids
+  security_groups = [aws_security_group.alb.id]
+}
+
+resource "aws_lb_target_group" "asg" {
+  name = "${var.cluster_name}-asg-example"
+  port = var.server_port
+  protocol = "HTTP"
+  vpc_id = data.aws_vpc.default.id
+  health_check {
+  path = "/"
+  protocol = "HTTP"
+  matcher = "200"
+  interval = 15
+  timeout = 3
+  healthy_threshold = 2
+  unhealthy_threshold = 2
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.example.arn
+  port = local.http_port
+  protocol = "HTTP"
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "404: page not found"
+      status_code = 404
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "asg" {
+  listener_arn = aws_lb_listener.http.arn
+  priority = 100
+  condition {
+    path_pattern {
+      values = ["*"]
+    }
+  }
+  action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.asg.arn
+  }
+}
+
+resource "aws_launch_configuration" "example" {
+  image_id = "ami-09eb4311cbaecf89d"
+  instance_type = var.instance_type
+  security_groups = [aws_security_group.instance.id]
+
+  user_data = templatefile("${path.module}/user-data.sh", {
+  server_port = var.server_port
+  db_address = data.terraform_remote_state.db.outputs.address
+  db_port = data.terraform_remote_state.db.outputs.port
+  })
+
+  lifecycle{
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "example" {
+  launch_configuration = aws_launch_configuration.example.name
+  vpc_zone_identifier = data.aws_subnets.default.ids
+  target_group_arns = [aws_lb_target_group.asg.arn]
+  health_check_type = "ELB"
+  min_size = var.min_size
+  max_size = var.max_size
+  tag {
+    key = "Name"
+    value = "terraform-asg-example"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name = "${var.cluster_name}-instance"
+
+  ingress {
+    from_port = var.server_port
+    to_port = var.server_port
+    protocol = "tcp"
+    cidr_blocks = [ "0.0.0.0/0" ]
+  }
+}

--- a/module/services/webserver-cluster/outputs.tf
+++ b/module/services/webserver-cluster/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_dns_name" {
+  value = aws_lb.example.dns_name
+  description = "The domain name of the load balancer"
+}
+
+output "asg_name" {
+  value = aws_autoscaling_group.example.name
+  description = "The name of the Auto Scaling Group"
+}
+
+output "alb_security_group_id" {
+ value = aws_security_group.alb.id
+ description = "The ID of the Security Group attached to the load balancer"
+}

--- a/module/services/webserver-cluster/user-data.sh
+++ b/module/services/webserver-cluster/user-data.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cat > index.html <<EOF
+<h1>Hello, World</h1>
+<p>DB address: ${db_address}</p>
+<p>DB port: ${db_port}</p>
+EOF
+nohup busybox httpd -f -p ${server_port} &

--- a/module/services/webserver-cluster/variables.tf
+++ b/module/services/webserver-cluster/variables.tf
@@ -1,0 +1,55 @@
+variable "cluster_name" {
+  description = "The name to use for all the cluster resources"
+  type = string
+}
+
+variable "db_remote_state_bucket" {
+  description = "The name of the S3 bucket for the database's remote state"
+  type = string
+}
+
+variable "db_remote_state_key" {
+  description = "The path for the database's remote state in S3"
+  type = string
+}
+
+variable "server_port" {
+  description = "server port for http request"
+  type = number
+  default = 8080
+}
+
+variable "instance_type" {
+  description = "The type of EC2 instances to run"
+  type = string
+}
+
+variable "min_size" {
+  description = "The minimum number of EC2 Instance"
+  type = number
+}
+
+variable "max_size" {
+  description = "The maximum number of EC2 Instance"
+  type = number
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "terraform_remote_state" "db" {
+  backend = "s3" 
+  config = {
+  bucket = var.db_remote_state_bucket 
+  key = var.db_remote_state_key 
+  region = "ap-northeast-2"
+  }
+}

--- a/prod/services/webserver-cluster/main.tf
+++ b/prod/services/webserver-cluster/main.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+resource "aws_autoscaling_schedule" "scale_out_during_business_hours" {
+  scheduled_action_name = "scale-out-during-business-hours"
+  min_size = 2
+  max_size = 10
+  desired_capacity = 10
+  recurrence = "0 9 * * *"
+  autoscaling_group_name = module.webserver_cluster.asg_name
+}
+
+resource "aws_autoscaling_schedule" "scale_in_at_night" {
+  scheduled_action_name = "scale-in-at-night"
+  min_size = 2
+  max_size = 10
+  desired_capacity = 2
+  recurrence = "0 17 * * *"
+  autoscaling_group_name = module.webserver_cluster.asg_name
+}
+
+module "webserver_cluster" {
+  source = "../../../module/services/webserver-cluster"
+  cluster_name = "webserver-prod"
+  db_remote_state_bucket = "terraform-state-cloudwave-15"
+  db_remote_state_key = "pord/data-stores/mysql/terraform.tfstate"
+}

--- a/prod/services/webserver-cluster/outputs.tf
+++ b/prod/services/webserver-cluster/outputs.tf
@@ -1,4 +1,4 @@
 output "alb_dns_name" {
-  value = module.webserver_cluster.alb_dns_name 
+  value = module.webserver_cluster.alb_dns_name
   description = "The domain name of the load balancer"
 }

--- a/stage/services/webserver-cluster/main.tf
+++ b/stage/services/webserver-cluster/main.tf
@@ -2,110 +2,21 @@ provider "aws" {
   region = "ap-northeast-2"
 }
 
-resource "aws_security_group" "alb" {
-  name = "terraform-example-alb"
-  ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-  egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_lb" "example" {
-  name = "terraform-asg-example"
-  load_balancer_type = "application"
-  subnets = data.aws_subnets.default.ids
-  security_groups = [aws_security_group.alb.id]
-}
-
-resource "aws_lb_target_group" "asg" {
-  name = "terraform-asg-example"
-  port = var.server_port
-  protocol = "HTTP"
-  vpc_id = data.aws_vpc.default.id
-  health_check {
-  path = "/"
-  protocol = "HTTP"
-  matcher = "200"
-  interval = 15
-  timeout = 3
-  healthy_threshold = 2
-  unhealthy_threshold = 2
-  }
-}
-
-resource "aws_lb_listener" "http" {
-  load_balancer_arn = aws_lb.example.arn
-  port = 80
-  protocol = "HTTP"
-  default_action {
-    type = "fixed-response"
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "404: page not found"
-      status_code = 404
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "asg" {
-  listener_arn = aws_lb_listener.http.arn
-  priority = 100
-  condition {
-    path_pattern {
-      values = ["*"]
-    }
-  }
-  action {
-    type = "forward"
-    target_group_arn = aws_lb_target_group.asg.arn
-  }
-}
-
-resource "aws_launch_configuration" "example" {
-  image_id = "ami-09eb4311cbaecf89d"
+module "webserver_cluster" {
+  source = "../../../module/services/webserver-cluster"
+  cluster_name = "webserver-stage"
+  db_remote_state_bucket = "terraform-state-cloudwave-15"
+  db_remote_state_key = "stage/data-stores/mysql/terraform.tfstate"
   instance_type = "t3.micro"
-  security_groups = [aws_security_group.instance.id]
-
-  user_data = templatefile("user-data.sh", {
-  server_port = var.server_port
-  db_address = data.terraform_remote_state.db.outputs.address
-  db_port = data.terraform_remote_state.db.outputs.port
-  })
-
-  lifecycle{
-    create_before_destroy = true
-  }
-}
-
-resource "aws_autoscaling_group" "example" {
-  launch_configuration = aws_launch_configuration.example.name
-  vpc_zone_identifier = data.aws_subnets.default.ids
-  target_group_arns = [aws_lb_target_group.asg.arn]
-  health_check_type = "ELB"
   min_size = 2
   max_size = 10
-  tag {
-    key = "Name"
-    value = "terraform-asg-example"
-    propagate_at_launch = true
-  }
 }
 
-resource "aws_security_group" "instance" {
-  name = "terraform-example-instance"
-
-  ingress {
-    from_port = var.server_port
-    to_port = var.server_port
-    protocol = "tcp"
-    cidr_blocks = [ "0.0.0.0/0" ]
-  }
+resource "aws_security_group_rule" "allow_testing_inbound" {
+  type = "ingress"
+  security_group_id = module.webserver_cluster.alb_security_group_id
+  from_port = 12345
+  to_port = 12345
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
## 모듈로 재사용 가능한 인프라 구성 ##
- 모듈은 재사용, 유지 관리 가능한 Terraform 코드를 작성하는 핵심 요소
- 여러 위치에서 재사용 가능한 모듈을 만들고, 이를 참조하는 방식을 통해 똑같은 코드를 여러 곳에 작성할 필요 없음

## 작업 내용 ##
- #1 에서 했던 webserver 환경 구축을 모듈로 분리
- 다른 환경(stage, prod디렉토리)에서는 webserver환경 구축을 모듈을 참조하도록 하는 terraform코드만 작성하면 됨
- 모듈을 이용하여 webserver인프라 프로비저닝
- 모듈 지역화(local)을 이용하여 변수를 locals.tf파일에 정의해두고, 이 변수를 모듈 전체에서 사용 가능하게함